### PR TITLE
Add time between created data

### DIFF
--- a/src/Controllers/FakeDataController.php
+++ b/src/Controllers/FakeDataController.php
@@ -25,10 +25,12 @@ class FakeDataController implements RequestHandlerInterface
     protected $inBulkMode = false;
     protected $bulkModeCache = [];
     protected $timer;
+    protected $translator;
 
-    public function __construct(FakeDataParametersValidator $validator)
+    public function __construct(FakeDataParametersValidator $validator, TranslatorInterface $translator)
     {
         $this->validator = $validator;
+        $this->translator = $translator;
     }
 
     protected function reuseInBulkMode(string $key, callable $callback)
@@ -106,7 +108,7 @@ class FakeDataController implements RequestHandlerInterface
             if ($userQuery->count() === 0) {
                 throw new ValidationException([
                     'users' => [
-                        app(TranslatorInterface::class)->trans('migratetoflarum-fake-data.api.no-users-matched'),
+                        $this->translator->trans('migratetoflarum-fake-data.api.no-users-matched'),
                     ],
                 ]);
             }
@@ -151,7 +153,7 @@ class FakeDataController implements RequestHandlerInterface
             if ($discussionQuery->count() === 0) {
                 throw new ValidationException([
                     'discussions' => [
-                        app(TranslatorInterface::class)->trans('migratetoflarum-fake-data.api.no-discussions-matched'),
+                        $this->translator->trans('migratetoflarum-fake-data.api.no-discussions-matched'),
                     ],
                 ]);
             }

--- a/src/Controllers/FakeDataController.php
+++ b/src/Controllers/FakeDataController.php
@@ -24,6 +24,7 @@ class FakeDataController implements RequestHandlerInterface
     protected $validator;
     protected $inBulkMode = false;
     protected $bulkModeCache = [];
+    protected $timer;
 
     public function __construct(FakeDataParametersValidator $validator)
     {
@@ -83,7 +84,7 @@ class FakeDataController implements RequestHandlerInterface
                     return $faker->flarumUnique()->userName;
                 }) . $bulkUserIncrement : $faker->flarumUnique()->userName;
             $user->is_email_confirmed = true;
-            $user->joined_at = Carbon::now();
+            $user->joined_at = $this->getTime();
             $user->save();
 
             $userIds[] = $user->id;
@@ -131,6 +132,7 @@ class FakeDataController implements RequestHandlerInterface
                 return implode("\n\n", $faker->paragraphs($faker->numberBetween(1, 10)));
             });
             $post = CommentPost::reply($discussion->id, $content, $author->id, null);
+            $post->created_at = $this->getTime();
             $post->save();
         }
 
@@ -170,6 +172,7 @@ class FakeDataController implements RequestHandlerInterface
                     return implode("\n\n", $faker->paragraphs($faker->numberBetween(1, 10)));
                 });
                 $post = CommentPost::reply($discussion->id, $content, $author->id, null);
+                $post->created_at = $this->getTime();
                 $post->save();
             }
         }
@@ -186,5 +189,15 @@ class FakeDataController implements RequestHandlerInterface
         }
 
         return new EmptyResponse(204);
+    }
+
+    public function getTime() {
+        if (is_null($this->timer)) {
+            $this->timer = Carbon::now()->subDays(15);
+        }
+
+        $this->timer->addMinutes(rand(0, 10));
+
+        return $this->timer;
     }
 }

--- a/src/Controllers/FakeDataController.php
+++ b/src/Controllers/FakeDataController.php
@@ -195,7 +195,7 @@ class FakeDataController implements RequestHandlerInterface
 
     public function getTime() {
         if (is_null($this->timer)) {
-            $this->timer = Carbon::now()->subDays(15);
+            $this->timer = Carbon::now();
         }
 
         $this->timer->addMinutes(rand(0, 10));


### PR DESCRIPTION
Time starts now, so data gets created in the future, but that doesn't matter for the UI, since that still displays "a few seconds ago". It does, however, ensure that huge discussions (thousands of posts) don't go wonky